### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/templates/lambda-at-edge.template
+++ b/templates/lambda-at-edge.template
@@ -175,7 +175,7 @@ Resources:
     Properties: 
       Handler: index.handler
       Role: !GetAtt EdgeAuthExecutionRole.Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 1
       MemorySize: 128
       Code:


### PR DESCRIPTION
CloudFormation templates in authorization-lambda-at-edge have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.