### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/node/lambda-edge-function/template.yaml
+++ b/node/lambda-edge-function/template.yaml
@@ -5,7 +5,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Environment:
         Variables:
           REGION: us-east-1

--- a/templates/lambda-at-edge.template
+++ b/templates/lambda-at-edge.template
@@ -175,7 +175,7 @@ Resources:
     Properties: 
       Handler: index.handler
       Role: !GetAtt EdgeAuthExecutionRole.Arn
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: 1
       MemorySize: 128
       Code:


### PR DESCRIPTION
CloudFormation templates in authorization-lambda-at-edge have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.