### PR TITLE
Upgrade runtime nodejs14.x and python3.6

### DIFF
--- a/templates/cognito-user-pool.template
+++ b/templates/cognito-user-pool.template
@@ -50,7 +50,7 @@ Resources:
     Properties: 
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
-      Runtime: python3.6
+      Runtime: python3.9
       Timeout: 60
       Code: 
         ZipFile: |

--- a/templates/lambda-at-edge.template
+++ b/templates/lambda-at-edge.template
@@ -55,7 +55,7 @@ Resources:
     Properties: 
       Handler: index.handler
       Role: !GetAtt UpdateConfigExecutionRole.Arn
-      Runtime: python3.6
+      Runtime: python3.9
       Timeout: 60
       MemorySize: 1536
       Code: 
@@ -175,7 +175,7 @@ Resources:
     Properties: 
       Handler: index.handler
       Role: !GetAtt EdgeAuthExecutionRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs16.x
       Timeout: 1
       MemorySize: 128
       Code:

--- a/templates/populate-s3-bucket.template
+++ b/templates/populate-s3-bucket.template
@@ -67,7 +67,7 @@ Resources:
     Properties: 
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
-      Runtime: python3.6
+      Runtime: python3.9
       Timeout: 60
       MemorySize: 1536
       Code: 
@@ -131,7 +131,7 @@ Resources:
     Properties: 
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
-      Runtime: python3.6
+      Runtime: python3.9
       Timeout: 30
       MemorySize: 1536
       Code: 


### PR DESCRIPTION
*Issue #13*

*Description of changes:*
Node 14.x and python3.6 are not supported.
Updated to Node16.x and python3.9.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
